### PR TITLE
changed dockerfile for dotaservice to use 'latest' dota tag

### DIFF
--- a/docker/Dockerfile-dotaservice
+++ b/docker/Dockerfile-dotaservice
@@ -1,4 +1,4 @@
-FROM dota:7.20d
+FROM dota:latest
 MAINTAINER Tim Zaman <timbobel@gmail.com>
 
 RUN apt-get -q update \


### PR DESCRIPTION
Following the README.md for the docker wasn't working for me as the dotaservice was using dota:7.20d tag as reference. I changed it to "latest" to fix and since 7.20e came out.