### PR TITLE
Getting Example/Client.py Running

### DIFF
--- a/docker/Dockerfile-dotaservice
+++ b/docker/Dockerfile-dotaservice
@@ -1,4 +1,4 @@
-FROM dota:7.20d
+FROM dota:latest
 MAINTAINER Tim Zaman <timbobel@gmail.com>
 
 RUN apt-get -q update \

--- a/dotaservice/__main__.py
+++ b/dotaservice/__main__.py
@@ -21,7 +21,8 @@ def get_default_action_path():
     if platform == "linux" or platform == "linux2":
         action_path = "/tmp/"
     elif platform == "darwin":
-        action_path = "/Volumes/ramdisk/"
+        #action_path = "/Volumes/ramdisk/"
+        action_path = "/tmp/"
     return action_path
 
 

--- a/examples/client.py
+++ b/examples/client.py
@@ -7,7 +7,6 @@ import uuid
 
 from grpclib.client import Channel
 from google.protobuf.json_format import MessageToDict
-from tensorboardX import SummaryWriter
 
 from dotaservice.protos.DotaService_grpc import DotaServiceStub
 from dotaservice.protos.dota_gcmessages_common_bot_script_pb2 import CMsgBotWorldState
@@ -31,6 +30,7 @@ GUI_DEBUG = True
 N_STEPS = 10 if GUI_DEBUG else 10
 
 if not GUI_DEBUG:
+    from tensorboardX import SummaryWriter
     writer = SummaryWriter()
     log_dir = writer.file_writer.get_logdir()
 
@@ -140,8 +140,13 @@ eps = np.finfo(np.float32).eps.item()
 START_EPISODE = 3488
 MODEL_FILENAME_FMT = "model_%09d.pt"
 pretrained_model = 'runs/Dec12_21-41-31_Tims-Mac-Pro.local/' + MODEL_FILENAME_FMT % START_EPISODE
-policy.load_state_dict(torch.load(pretrained_model), strict=True)
 
+try:
+    policy.load_state_dict(torch.load(pretrained_model), strict=True)
+except FileNotFoundError:
+    START_EPISODE = 0
+    print("Model '%s' Not Found. Starting from scratch at episode %d" % (pretrained_model, START_EPISODE))
+    pass
 
 def select_action(world_state, step=None):
     actions = {}

--- a/examples/requirements.pip
+++ b/examples/requirements.pip
@@ -1,0 +1,2 @@
+torch
+tensorboardX


### PR DESCRIPTION
So I'm running this as a test on my OSX box. I needed to make the following changes to get the examples/client.py up and running.

I still do have questions about where the config file exists and how to get it to render (apparently I should just be able to send the render=True in the config file, but not sure where the config is -- I realize it is a dotaservice protobuf construct but never seen it).

Also, a README on the order of operations dotaservice tries to execute would be beneficial I think as based on console messages it seems to try and run the C++ bots first, fails, then defaults to Lua scripts. It then tries to load the "team_desires.lua" which you haven't stubbed out yet, fails, but seems to continue.

I can fix the desires and such but would love some more explanation and perhaps even a pretrained model you might have. 

Perhaps we can setup a discord channel we can chat on or leave messages?