### PR TITLE
disable default item buying

### DIFF
--- a/dotaservice/lua/item_purchase_generic.lua
+++ b/dotaservice/lua/item_purchase_generic.lua
@@ -1,0 +1,10 @@
+-- Implementing this function in this file
+-- prevents bots from ever buying any items
+-- by default from default bot scripts 
+-- implemented by Valve. For bots to buy
+-- items now, we will have to implement
+-- our own logic for buying items.
+
+function ItemPurchaseThink()
+    return
+end


### PR DESCRIPTION
by using "item_purchase_generic" we disable bots from buying items by default.

You can also control a specific heroes behavior by creating a file called "item_purchase_<heroname>.lua" but we want our own control of item buying by RL.