### PR TITLE
Update pip to code at head

### DIFF
--- a/dotaservice/dotaservice.py
+++ b/dotaservice/dotaservice.py
@@ -274,13 +274,7 @@ class DotaGame(object):
         if self.host_mode == HOST_MODE_GUI_MENU:
             args.extend(['+sv_lan', '0'])
 
-        # Supress stdout if the logger level is info.
-        stdout = None if logger.level == 'INFO' else asyncio.subprocess.PIPE
-
-        create = asyncio.create_subprocess_exec(
-            *args,
-            stdin=asyncio.subprocess.PIPE, stdout=stdout, stderr=stdout,
-        )
+        create = asyncio.create_subprocess_exec(*args, stdin=asyncio.subprocess.PIPE)
         self.process = await create
 
         task_monitor_log = asyncio.create_task(self.monitor_log())


### PR DESCRIPTION
Assigning the dota2 subprocess' `stdout` to `subprocess.PIPE` blocks all console logging. When `stdout == subprocess.PIPE`, the dota2 process will not write anything to its console logs, regardless of the value of the `-console` or `-con_logfile` or dota2 flags. My guess is that since nothing is consuming that pipe, the dota2 console ends up being blocked since it can't write anything to a pipe that isn't being consumed.

Tested via manual editing of the source code in my local workspace to verify what was happening.